### PR TITLE
Change the package replace rule to work on windows also

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'com.metapack.ddo'
-version = '1.2.6'
+version = '1.2.7'
 
 repositories.jcenter()
 

--- a/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
+++ b/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
@@ -100,7 +100,7 @@ class GatlingPlugin implements Plugin<Project> {
         sourceSet.allScala.files*.toString().
                 findAll { it.endsWith 'Scenario.scala' }.
                 collect { it[scenarioPathPrefix..scenarioPathSuffix] }*.
-                replace('/', '.')
+                replace(System.getProperty("file.separator"), '.')
     }
 
     private firstPath(Set<File> files) {


### PR DESCRIPTION
I've changed the way the full className is created (package+class) to get scenario name.
By using the file.separator, this should work on Linux and Windows.
